### PR TITLE
Add workflows for updating devel:languages:perl

### DIFF
--- a/.github/workflows/run.yaml
+++ b/.github/workflows/run.yaml
@@ -10,7 +10,7 @@ on:
       image:
         description: Image to run on
         type: string
-        default: registry.opensuse.org/home/tinita/branches/opensuse/templates/images/tumbleweed/containers/opensuse/example
+        default: registry.opensuse.org/home/tinita/cpanspec/container/containers/opensuse/autoupdate-perl
       repo:
         description: Repo for cpanspec
         type: string
@@ -18,14 +18,21 @@ on:
       branch:
         description: cpanspec branch
         type: string
-        default: update-perl-gh
+        default: normalize-versions
+      obs_project:
+        description: Target project in OBS
+        type: string
+        default: devel:languages:perl:autoupdate
+      cpanspec_flags:
+        description: Additional flags for cpanspec
+        type: string
+        default: --dlp
 
 jobs:
 
   update:
     runs-on: ubuntu-latest
     container:
-      #image: registry.opensuse.org/opensuse/leap:15.5
       image: ${{ inputs.image }}
 
     steps:
@@ -34,3 +41,58 @@ jobs:
         git config --global --add safe.directory '*'
 
     - uses: actions/checkout@v4
+
+    - run: |
+        git clone ${{ inputs.repo }} -b ${{ inputs.branch }}
+
+    - name: configure osc
+      env:
+        OSC_USER: ${{ secrets.OSC_USER }}
+        OSC_PASSWORD: ${{ secrets.OSC_PASSWORD }}
+      run: |
+        cp etc/oscrc ~/.oscrc
+        perl -pi -wE's/OSC_USER/$ENV{OSC_USER}/' ~/.oscrc
+        perl -pi -wE's/OSC_PASSWORD/$ENV{OSC_PASSWORD}/' ~/.oscrc
+
+    - name: fetch cpan releases
+      run: |
+        bin/fetch-cpan.sh
+        ls -lrt ~/obs-mirror
+        ls -lrt ~/obs-mirror/cpan
+
+    - name: status
+      run: |
+        ./bin/status-perl --data ~/obs-mirror --project ${{ inputs.obs_project }} --update
+        grep $'\t''todo' ~/obs-mirror/status/*.tsv || true
+
+    - name: update
+      run: |
+        ./bin/update-perl \
+            --cpanspec "$PWD/cpanspec/cpanspec" \
+            --data ~/obs-mirror \
+            --project "${{ inputs.obs_project }}" \
+            --max "${{ inputs.max_modules }}" \
+            --cpanspec-flags " ${{ inputs.cpanspec_flags }}"
+
+    - name: check
+      run: |
+        if ! grep $'\t''error' ~/obs-mirror/status/*; then
+            echo "Updates successful"
+        else
+            echo "Some updates failed!"; false
+        fi
+        ls -lrt ~/obs-mirror
+        ls -lrt ~/obs-mirror/status
+
+    - uses: actions/upload-artifact@v4
+      if: ${{ always() }}
+      with:
+        name: obs-mirror
+        path: |
+          ~/obs-mirror/cpan/
+          ~/obs-mirror/status/
+          ~/obs-mirror/auto.xml
+          ~/obs-mirror/perl.xml
+
+# Trigger with gh cli:
+# gh workflow run run.yaml [--ref branch] -f image=registry.opensuse.org/home/tinita/cpanspec/container/containers/opensuse/autoupdate-perl -f repo=https://github.com/perlpunk/cpanspec -f branch=normalize-versions -f obs_project=devel:languages:perl:autoupdate -f max_modules=1

--- a/.github/workflows/trigger-perl-update.yaml
+++ b/.github/workflows/trigger-perl-update.yaml
@@ -1,0 +1,28 @@
+name: Trigger Update devel:languages:perl
+on:
+  push:
+    # Push a branch named cron-test to trigger this workflow
+    branches: [cron-test]
+  workflow_dispatch:
+  schedule:
+  - cron: 15 5 * * *
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - env:
+        GH_TOKEN: ${{ github.token }}
+      name: Trigger
+      if: ${{ vars.ENABLED == 1 }}
+      run: |
+        gh workflow list
+        gh workflow run run.yaml --ref workflow \
+            -f "image=${{ vars.IMAGE }}" \
+            -f "repo=${{ vars.REPO }}" \
+            -f "branch=${{ vars.BRANCH }}" \
+            -f "obs_project=${{ vars.OBS_PROJECT }}" \
+            -f "max_modules=${{ vars.MAX_MODULES }}" \
+            -f "cpanspec_flags=${{ vars.CPANSPEC_FLAGS }}"
+

--- a/bin/fetch-cpan
+++ b/bin/fetch-cpan
@@ -22,6 +22,8 @@ my $details_url = "http://www.cpan.org/modules/02packages.details.txt.gz";
 my @skip = qw/
     Acme-DependOnEverything
     Acme-Shining
+    MARC-Lint
+    Unix-Mknod
 /;
 my %skip;
 @skip{ @skip } = (1) x @skip;

--- a/bin/update
+++ b/bin/update
@@ -39,7 +39,7 @@ my $cpan2obs = CPAN2OBS->new({
     data => $data,
     cpanmirror => 'http://cpan.noris.de',
     apiurl => 'https://api.opensuse.org',
-    cpanspec => "$Bin/../cpanspec",
+    cpanspec => $ENV{CPANSPEC} || "$Bin/../../cpanspec/cpanspec",
     project_prefix => $project,
 });
 

--- a/bin/update-perl
+++ b/bin/update-perl
@@ -17,6 +17,8 @@ GetOptions(
     'project=s' => \my $project,
     'package=s@' => \my @packages,
     'redo' => \my $redo,
+    'cpanspec=s' => \my $cpanspec,
+    'cpanspec-flags=s' => \my $cpanspec_flags,
     'help|h' => \my $help,
 );
 usage(), exit if $help;
@@ -28,7 +30,8 @@ my $cpan2obs = CPAN2OBS->new({
     data => $data,
     cpanmirror => 'http://cpan.metacpan.org',
     apiurl => 'https://api.opensuse.org',
-    cpanspec => "$Bin/../cpanspec",
+    cpanspec => $cpanspec || "$Bin/../../cpanspec/cpanspec",
+    cpanspec_flags => $cpanspec_flags || '',
     project_prefix => $project,
 });
 

--- a/etc/oscrc
+++ b/etc/oscrc
@@ -1,0 +1,7 @@
+[general]
+apiurl = https://api.opensuse.org
+
+[https://api.opensuse.org]
+user = OSC_USER
+pass = OSC_PASSWORD
+credentials_mgr_class=osc.credentials.ObfuscatedConfigFileCredentialsManager

--- a/lib/CPAN2OBS.pm
+++ b/lib/CPAN2OBS.pm
@@ -29,6 +29,7 @@ has skip => ( is => 'ro' );
 has apiurl => ( is => 'ro' );
 has cpanmirror => ( is => 'ro' );
 has cpanspec => ( is => 'ro' );
+has cpanspec_flags => ( is => 'ro' );
 has project_prefix => ( is => 'ro', coerce => \&_coerce_project_prefix );
 has locked => ( is => 'rw' );
 
@@ -500,6 +501,7 @@ sub osc_update_dist {
     my $apiurl = $self->apiurl;
     my $mirror = $self->cpanmirror;
     my $cpanspec = $self->cpanspec;
+    my $cpanspec_flags = $self->cpanspec_flags;
     my $project_prefix = $self->project_prefix . $letter;
 
     my $osc = "$data/osc";
@@ -525,7 +527,7 @@ sub osc_update_dist {
     my $error = 1;
     {
         my $cmd = sprintf
-            "timeout 180 perl $cpanspec -v -f --pkgdetails %s --skip-changes %s > cpanspec.error 2>&1",
+            "timeout 180 perl $cpanspec $cpanspec_flags -v -f --pkgdetails %s --skip-changes %s > cpanspec.error 2>&1",
             "$data/02packages.details.txt.gz", $tar;
         debug("CMD $cmd");
         if (system $cmd or not -f $spec) {
@@ -609,6 +611,7 @@ sub osc_update_dist_perl {
     my $apiurl = $self->apiurl;
     my $mirror = $self->cpanmirror;
     my $cpanspec = $self->cpanspec;
+    my $cpanspec_flags = $self->cpanspec_flags;
     my $project_prefix = $self->project_prefix;
     my $letter = 'perl';
 
@@ -671,7 +674,7 @@ sub osc_update_dist_perl {
     copy("$Bin/../cpanspec.yml", "$checkout/cpanspec.yml") unless -f "cpanspec.yml";
     {
         my $cmd = sprintf
-            "timeout 900 perl $cpanspec -v -f --pkgdetails %s --old-file %s %s > cpanspec.error 2>&1",
+            "timeout 900 perl $cpanspec $cpanspec_flags -v -f --pkgdetails %s --old-file %s %s > cpanspec.error 2>&1",
             "$data/02packages.details.txt.gz", ".osc/$old_tar", $tar;
         debug("CMD $cmd");
         if (system $cmd or not -f $spec) {


### PR DESCRIPTION
Issue: https://progress.opensuse.org/issues/160688

With this https://build.opensuse.org/project/show/devel:languages:perl:autoupdate can be updated via the cron workflow automatically, or on request via dispatching the workflow manually over the web ui or the API.

* The cpanspec clone still points to my fork as there is ongoing work regarding normalizing versions
* The automatic cron is still disabled, as I still work on it and want to run it manually