### PR TITLE
Save cache file as YAML

### DIFF
--- a/lib/CPAN2OBS.pm
+++ b/lib/CPAN2OBS.pm
@@ -316,6 +316,7 @@ sub store_obs_cache {
     mkdir "$data/obs-cache" unless -d "$data/obs-cache";
     my $cachefile = "$data/obs-cache/$letter";
     store $cache, $cachefile;
+    DumpFile "$cachefile.yaml", $cache;
 }
 
 sub create_package_xml {


### PR DESCRIPTION
Improves possibility to debug.

The Storable file can be removed after every file has been converted to YAML.

Also funnily the YAML files are smaller.