### PR TITLE
Revert "Add sccs dependency for vc"

### DIFF
--- a/etc/container/Dockerfile
+++ b/etc/container/Dockerfile
@@ -23,7 +23,6 @@ RUN zypper install -y -C \
         obs-service-download_files \
         osc \
         procmail \
-        sccs \
         tar \
         wget \
         'perl(Algorithm::Diff)' \


### PR DESCRIPTION
Reverts openSUSE/autoupdate-perl#7

The `vc` command seems to be not what we want here. 
See discussion in https://github.com/openSUSE/cpanspec/pull/54